### PR TITLE
improvement - inlined css in header

### DIFF
--- a/src/reqT/export.scala
+++ b/src/reqT/export.scala
@@ -239,16 +239,29 @@ trait FileExporter extends StringExporter {
 
 trait HtmlExporter extends FileExporter {
   override def defaultOutputFile: String = "index.html"
-  override def preamble(m: Model): String = s"""
-     |<!DOCTYPE html>
-     |<html>
-     |<head>
-     |<title>${titleOrDefault(m)}</title>
-     |<link rel="stylesheet" type="text/css" href="reqT-style.css">
-     |</head>
-  """.stripMargin
+  override def preamble(m: Model): String =  {
+    var css: String = ""
+
+    scala.util.Try {
+      css = s"""
+        |<style>
+        |${fileUtils.loadResource("/reqT-style.css").mkString("\n")}
+        |</style>
+        """.stripMargin
+    }.recover { case e => println("resources/reqT-style.css not found - ignoring") }
+
+    s"""
+    |<!DOCTYPE html>
+    |<html>
+    |<head>
+    |<title>${titleOrDefault(m)}</title>
+    |$css
+    |</head>
+    """.stripMargin
+  }
+
   override def ending(m: Model): String = "</html>\n"
-  override def body(m: Model): String = 
+  override def body(m: Model): String =
     "<body>\n" + exportTopModel(m) + "\n</body>\n"
 
   def topLevelSectionsContents(m: Model): String = topLevelSections(m).

--- a/src/reqT/gui.scala
+++ b/src/reqT/gui.scala
@@ -735,11 +735,6 @@ object gui { //GUI implementation
         val ioFile = new java.io.File(choice)
         val (dir, file) = (ioFile.getParent, ioFile.getName)
         export.toHtml(exportModel(), dir, file)
-        val css = "/reqT-style.css"
-        Try {
-          if (!fileUtils.exists(dir+css))
-            fileUtils.loadResource(css).mkString("\n").save(dir+css)
-        } .recover { case e => println(e); msgError(s"Error saving $css, see console message.")  }
         println(s"Desktop open: $choice")
         desktopOpen(choice)
       }


### PR DESCRIPTION
Achieves: Styling is accompanied with the HTML file if user saves their model from the reqT-REPL

If stylesheet is not found:

```
reqT> res0.toHtml.save("myModel.html")
resources/reqT-style.css not found - ignoring
Saved string to file: git/notes/reqt-webapp/LAB1/myModel.html
```

and the `<style>` field is omitted from the header.

If stylesheet exists:

```
reqT> res0.toHtml.save(world.html)
Saved string to file: git/notes/reqt-webapp/LAB1/world.html
```

and the `resources/reqT-style.css` stylesheet is inserted in the header.